### PR TITLE
update xtend

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/thlorenz/parse-link-header",
   "dependencies": {
-    "xtend": "~2.0.5"
+    "xtend": "~4.0.0"
   },
   "devDependencies": {
     "tape": "~1.0.3",


### PR DESCRIPTION
Removes sub-deps on two very old modules, `is-object` and `object-keys`. As far as I can tell, xtend's API is super stable and hasn't really changed. Tests pass. v0.1.1 would be nice so other modules can get this :)
