### PR TITLE
Fix parsing rels without quotes

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ function parseLink(link) {
     var info = parts
       .reduce(function (acc, p) {
         // rel="next" => 1: rel 2: next
-        var m = p.match(/ *(.+) *= *"(.+)"/)
+        var m = p.match(/\s*(.+)\s*=\s*"?([^"]+)"?/)
         if (m) acc[m[1]] = m[2];
         return acc;
       }, {});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parse-link-header",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Parses a link header and returns paging information for each contained link.",
   "main": "index.js",
   "scripts": {

--- a/test/parse-link-header.js
+++ b/test/parse-link-header.js
@@ -31,6 +31,33 @@ test('parsing a proper link header with next and last', function (t) {
   t.end()
 })
 
+test('handles unquoted relationships', function (t) {
+  var link = 
+    '<https://api.github.com/user/9287/repos?client_id=1&client_secret=2&page=2&per_page=100>; rel=next, ' + 
+    '<https://api.github.com/user/9287/repos?client_id=1&client_secret=2&page=3&per_page=100>; rel=last'
+
+  var res = parse(link)
+  t.deepEqual(
+      parse(link)
+    , { next:
+        { client_id: '1',
+          client_secret: '2',
+          page: '2',
+          per_page: '100',
+          rel: 'next',
+          url: 'https://api.github.com/user/9287/repos?client_id=1&client_secret=2&page=2&per_page=100' },
+        last:
+        { client_id: '1',
+          client_secret: '2',
+          page: '3',
+          per_page: '100',
+          rel: 'last',
+          url: 'https://api.github.com/user/9287/repos?client_id=1&client_secret=2&page=3&per_page=100' } }
+    , 'parses out link, page and perPage for next and last'
+  )
+  t.end()
+})
+
 test('parsing a proper link header with next, prev and last', function (t) {
   var linkHeader = 
     '<https://api.github.com/user/9287/repos?page=3&per_page=100>; rel="next", ' + 


### PR DESCRIPTION
There is actually nothing in [the spec](https://tools.ietf.org/html/rfc5988#page-7) that requires quotes around the rel type. This fixes that assumption and adds a test around it.